### PR TITLE
Global node-sass installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ At The `libsass` binding was not found in .... /node-sass/vendor/**/binding.node
 [To download the missing file](https://github.com/sass/node-sass/releases),
 If you follow the above solutions still wrong, then I am sorry only use css files.
 
+## Alternative to local node-sass installation
+If using a local `node-sass` package fails for you, you can install `node-sass` globally and enable the **useGlobalSass** option to be able to use .sass files once again.
+
+Take into consideration that this approach will use the same `node-sass` version for all your projects.
+
+To install `node-sass` globally follow this step:
+
+```bash
+$ npm install -g node-sass
+```
+
 ## Newly added
 Can insert JS code: `JS()`<br />
 New metering unit: `vw`, `vh`, `vmax`, `vmin`, `scale`<br />
@@ -35,6 +46,11 @@ New metering unit: `vw`, `vh`, `vmax`, `vmin`, `scale`<br />
 
 - #### enableSass
     Enable Sass file and install node-sass
+
+    *Default:* `false`
+
+- #### useGlobalSass
+    Enables Sass file parsing using a **globally** installed **node-sass** package
 
     *Default:* `false`
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -87,68 +87,68 @@ var compile = {
         obj[property] = compile.parseUnit(obj[property]);
     },
     parseCSS: function(filePath, outputFile, errorFunc) {
-      compile.doParse(fs.readFileSync(filePath, 'utf-8'), filePath, outputFile, errorFunc);
+        compile.doParse(fs.readFileSync(filePath, 'utf-8'), filePath, outputFile, errorFunc);
     },
     parseSCSSLocally: function(filePath, outputFile, errorFunc) {
-      var css = require('node-sass').renderSync({
-          file: filePath,
-          outputStyle: 'compressed'
-      }).css.toString();
+        var css = require('node-sass').renderSync({
+            file: filePath,
+            outputStyle: 'compressed'
+        }).css.toString();
 
-      compile.doParse(css,  filePath, outputFile, errorFunc);
+        compile.doParse(css,  filePath, outputFile, errorFunc);
     },
     parseSCSSGlobally: function(filePath, outputFile, errorFunc) {
-      var css,
-        isWin = process.platform == 'win32',
-        cmd = 'npm',
-        npmPrefix,
-        envObj,
-        cmdConvert,
-        partialPath = ['node_modules', 'node-sass'];
+        var css,
+          isWin = process.platform == 'win32',
+          cmd = 'npm',
+          npmPrefix,
+          envObj,
+          cmdConvert,
+          partialPath = ['node_modules', 'node-sass'];
 
-      // Determine the globally installed node-sass binary path
-      if (!pathToGlobalSCSS) {
-        // Clone the current environment
-        envObj = {};
-        Object.keys(process.env).forEach(function (k) {
-          envObj[k] = process.env[k];
-        });
+        // Determine the globally installed node-sass binary path
+        if (!pathToGlobalSCSS) {
+            // Clone the current environment
+            envObj = {};
+            Object.keys(process.env).forEach(function (k) {
+                envObj[k] = process.env[k];
+            });
 
-        // Make sure the path is valid on OS X
-        envObj.PATH = consistentPath();
+            // Make sure the path is valid on OS X
+            envObj.PATH = consistentPath();
 
-        if (isWin) {
-          cmd = 'npm.cmd';
-        } else {
-          // *NIX based systems keep global node modules under NPM_PREFIX/lib/...
-          partialPath.unshift('lib');
+            if (isWin) {
+                cmd = 'npm.cmd';
+            } else {
+                // *NIX based systems keep global node modules under NPM_PREFIX/lib/...
+                partialPath.unshift('lib');
+            }
+
+            // Get globally installed packages npm root
+            try {
+                npmPrefix = childProcess.spawnSync(cmd, ['get', 'prefix'], {
+                  env: envObj
+                }).output[1].toString().trim()
+            } catch (e) {
+                // Notify the user of the error, maybe he will install it!
+                throw new Error('Node-SASS is not installed globally! Please make sure to install node-sass before using the global option.');
+            }
+
+            // Add NPM prefix to the partial path
+            partialPath.unshift(npmPrefix);
+
+            // Cache the obtained path to the global SASS installation
+            pathToGlobalSCSS = path.join.apply(null, partialPath);
         }
 
-        // Get globally installed packages npm root
-        try {
-          npmPrefix = childProcess.spawnSync(cmd, ['get', 'prefix'], {
+        cmdConvert = path.join(pathToGlobalSCSS, 'bin', 'node-sass') + ' --output-style compressed ' + filePath;
+
+        // Forward to the globally installed node-sass module and wait for return
+        css = childProcess.execSync(cmdConvert, {
             env: envObj
-          }).output[1].toString().trim()
-        } catch (e) {
-          // Notify the user of the error, maybe he will install it!
-          throw new Error('Node-SASS is not installed globally! Please make sure to install node-sass before using the global option.');
-        }
+        }).toString();
 
-        // Add NPM prefix to the partial path
-        partialPath.unshift(npmPrefix);
-
-        // Cache the obtained path to the global SASS installation
-        pathToGlobalSCSS = path.join.apply(null, partialPath);
-      }
-
-      cmdConvert = path.join(pathToGlobalSCSS, 'bin', 'node-sass') + ' --output-style compressed ' + filePath;
-
-      // Forward to the globally installed node-sass module and wait for return
-      css = childProcess.execSync(cmdConvert, {
-        env: envObj
-      }).toString();
-
-      compile.doParse(css,  filePath, outputFile, errorFunc);
+        compile.doParse(css,  filePath, outputFile, errorFunc);
     },
     doParse: function (contents, filePath, outputFile, errorFunc) {
       try {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,7 +3,10 @@
 var path = require('path'),
     fs = require('fs'),
     css = require('css'),
-    camel = require('to-camel-case');
+    camel = require('to-camel-case'),
+    childProcess = require('child_process'),
+    consistentPath = require('consistent-path'),
+    pathToGlobalSCSS;
 
 var injectScript = `import React, {StyleSheet, Dimensions, PixelRatio} from "react-native";
 const {width, height, scale} = Dimensions.get("window"),
@@ -83,52 +86,115 @@ var compile = {
         obj[property] = compile.parseString(obj[property]);
         obj[property] = compile.parseUnit(obj[property]);
     },
-    parseJSS: function(filePath, outputFile, ext, errorFunc) {
-        var contents = ext == '.css' ? fs.readFileSync(filePath, 'utf-8') : require('node-sass').renderSync({
-            file: filePath,
-            outputStyle: 'compressed'
-        }).css.toString();
+    parseCSS: function(filePath, outputFile, errorFunc) {
+      compile.doParse(fs.readFileSync(filePath, 'utf-8'), filePath, outputFile, errorFunc);
+    },
+    parseSCSSLocally: function(filePath, outputFile, errorFunc) {
+      var css = require('node-sass').renderSync({
+          file: filePath,
+          outputStyle: 'compressed'
+      }).css.toString();
 
-        try {
-            contents = css.parse(contents.replace(/\r?\n|\r/g, ''));
-        } catch (e) {
-            //捕获css文件内容错误 sass文件错误编译时就回报错
-            contents = null;
-            errorFunc(filePath + '\n \n' + e);
-        } finally {
-            var cssJSON = {};
-            if (contents) {
-                contents.stylesheet.rules.forEach(function(rule) {
-                    if (rule.type !== 'rule') return;
+      compile.doParse(css,  filePath, outputFile, errorFunc);
+    },
+    parseSCSSGlobally: function(filePath, outputFile, errorFunc) {
+      var css,
+        isWin = process.platform == 'win32',
+        cmd = 'npm',
+        npmPrefix,
+        envObj,
+        cmdConvert,
+        partialPath = ['node_modules', 'node-sass'];
 
-                    rule.selectors.forEach(function(selector) {
-                        selector = selector.replace(/\.|#/g, '');
-                        cssJSON[selector] = cssJSON[selector] || {};
+      // Determine the globally installed node-sass binary path
+      if (!pathToGlobalSCSS) {
+        // Clone the current environment
+        envObj = {};
+        Object.keys(process.env).forEach(function (k) {
+          envObj[k] = process.env[k];
+        });
 
-                        rule.declarations.forEach(function(declaration) {
-                            if (declaration.type !== 'declaration') return;
-                            compile.formatJSS(cssJSON[selector], declaration.property, declaration.value);
-                        });
-                    });
-                });
-            }
+        // Make sure the path is valid on OS X
+        envObj.PATH = consistentPath();
 
-            //输出文件
-            var text = JSON.stringify(cssJSON, null, 4);
-
-            //处理js代码
-            var codes = text.match(/"JS\(([\s\S]*?)\)"/g);
-            if (codes) {
-                for (var i = 0; i < codes.length; i++) {
-                    text = text.replace(codes[i], codes[i].match(/"JS\(([\s\S]*?)\)"/)[1]);
-                }
-            }
-
-            var wstream = fs.createWriteStream(outputFile);
-            wstream.write(injectScript + "\nexport default StyleSheet.create(" + text + ");");
-            wstream.end();
+        if (isWin) {
+          cmd = 'npm.cmd';
+        } else {
+          // *NIX based systems keep global node modules under NPM_PREFIX/lib/...
+          partialPath.unshift('lib');
         }
+
+        // Get globally installed packages npm root
+        try {
+          npmPrefix = childProcess.spawnSync(cmd, ['get', 'prefix'], {
+            env: envObj
+          }).output[1].toString().trim()
+        } catch (e) {
+          // Notify the user of the error, maybe he will install it!
+          throw new Error('Node-SASS is not installed globally! Please make sure to install node-sass before using the global option.');
+        }
+
+        // Add NPM prefix to the partial path
+        partialPath.unshift(npmPrefix);
+
+        // Cache the obtained path to the global SASS installation
+        pathToGlobalSCSS = path.join.apply(null, partialPath);
+      }
+
+      cmdConvert = path.join(pathToGlobalSCSS, 'bin', 'node-sass') + ' --output-style compressed ' + filePath;
+
+      // Forward to the globally installed node-sass module and wait for return
+      css = childProcess.execSync(cmdConvert, {
+        env: envObj
+      }).toString();
+
+      compile.doParse(css,  filePath, outputFile, errorFunc);
+    },
+    doParse: function (contents, filePath, outputFile, errorFunc) {
+      try {
+          contents = css.parse(contents.replace(/\r?\n|\r/g, ''));
+      } catch (e) {
+          //捕获css文件内容错误 sass文件错误编译时就回报错
+          contents = null;
+          errorFunc(filePath + '\n \n' + e);
+      } finally {
+          var cssJSON = {};
+          if (contents) {
+              contents.stylesheet.rules.forEach(function(rule) {
+                  if (rule.type !== 'rule') return;
+
+                  rule.selectors.forEach(function(selector) {
+                      selector = selector.replace(/\.|#/g, '');
+                      cssJSON[selector] = cssJSON[selector] || {};
+
+                      rule.declarations.forEach(function(declaration) {
+                          if (declaration.type !== 'declaration') return;
+                          compile.formatJSS(cssJSON[selector], declaration.property, declaration.value);
+                      });
+                  });
+              });
+          }
+
+          //输出文件
+          var text = JSON.stringify(cssJSON, null, 4);
+
+          //处理js代码
+          var codes = text.match(/"JS\(([\s\S]*?)\)"/g);
+          if (codes) {
+              for (var i = 0; i < codes.length; i++) {
+                  text = text.replace(codes[i], codes[i].match(/"JS\(([\s\S]*?)\)"/)[1]);
+              }
+          }
+
+          var wstream = fs.createWriteStream(outputFile);
+          wstream.write(injectScript + "\nexport default StyleSheet.create(" + text + ");");
+          wstream.end();
+      }
     }
 };
 
-module.exports = compile.parseJSS;
+module.exports = {
+  parseCSS: compile.parseCSS,
+  parseSCSSLocally: compile.parseSCSSLocally,
+  parseSCSSGlobally: compile.parseSCSSGlobally
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,44 +228,45 @@ module.exports = {
         });
     },
     registerMutualExclusionOfNodeSassTypes: function () {
-      [packageName + '.useGlobalSass', packageName + '.enableSass'].forEach((k) => {
-        atom.config.onDidChange(k, (val) => {
-          if (!mutualExclusionInProgress) {
-            mutualExclusionInProgress = true;
-            var isGlobal = k.indexOf('useGlobalSass') > -1;
+        [packageName + '.useGlobalSass', packageName + '.enableSass'].forEach((k) => {
+            atom.config.onDidChange(k, (val) => {
+                if (!mutualExclusionInProgress) {
+                    mutualExclusionInProgress = true;
+                    var isGlobal = k.indexOf('useGlobalSass') > -1;
 
-            this.mutuallyExcludeNodeSassTypes({
-              global: isGlobal ? val.newValue : false,
-              local: !isGlobal ? val.newValue : false
+                    this.mutuallyExcludeNodeSassTypes({
+                        global: isGlobal ? val.newValue : false,
+                        local: !isGlobal ? val.newValue : false
+                    });
+                }
             });
-          }
         });
-      });
     },
     mutuallyExcludeNodeSassTypes: function (o) {
-      var localSass = packageName + '.enableSass',
-        globalSass = packageName + '.useGlobalSass',
-        unsetOption = function (o) {
-          if (atom.config.get(o)) {
-            atom.config.set(o, false);
-          }
-        };
+        var localSass = packageName + '.enableSass',
+          globalSass = packageName + '.useGlobalSass',
+          unsetOption = function (o) {
+              if (atom.config.get(o)) {
+                  atom.config.set(o, false);
+              }
+          };
 
-      // Remove the other option when one of them is selected
-      if (o.global || o.local) {
-        if (o.global) {
-          unsetOption(localSass);
+        // Remove the other option when one of them is selected
+        if (o.global || o.local) {
+            if (o.global) {
+                unsetOption(localSass);
+            } else {
+                unsetOption(globalSass);
+            }
         } else {
-          unsetOption(globalSass);
+            // Make sure both are unset
+            unsetOption(localSass);
+            unsetOption(globalSass);
         }
-      } else {
-        // Make sure both are unset
-        unsetOption(localSass);
-        unsetOption(globalSass);
-      }
-      setTimeout(() => {
-        mutualExclusionInProgress = false;
-      }, 10);
+
+        setTimeout(() => {
+            mutualExclusionInProgress = false;
+        }, 10);
     },
     getProvider: function() {
         return require('./provider.js');

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ var path = require('path'),
     execSync = require('child_process').execSync,
     minimatch = require('minimatch'),
     compile = require('./compile.js'),
-    detector = require('./file-detector.js');
+    detector = require('./file-detector.js'),
+    mutualExclusionInProgress = false;
 
 var packageName = 'atom-react-native-css';
 
@@ -25,19 +26,27 @@ module.exports = {
             "default": false,
             order: 12,
         },
+        useGlobalSass: {
+            title: 'Enable Sass file and use globally installed node-sass',
+            description: 'This option is mutually exclusive with "Enable Sass file and install node-sass".',
+            type: 'boolean',
+            "default": false,
+            order: 13,
+            enabled: false
+        },
         input: {
             title: 'Input files',
             description: 'Enter the file path or directory. Please read minimatch matching rules',
             type: 'string',
             "default": '**/*.@(css|scss|sass)',
-            order: 13
+            order: 14
         },
         output: {
             title: 'Output file',
             description: 'File output directory. Relative to the path of the input file',
             type: 'string',
             "default": './',
-            order: 14
+            order: 15
         }
     },
     installationDir: '',
@@ -45,6 +54,7 @@ module.exports = {
     nodeSassInstallState: -1, //node-sass安装状态 -1:未安装,0:已安装,1:正在安装
     activate: function() {
         this.hasInstallNodeSass();
+        this.registerMutualExclusionOfNodeSassTypes();
 
         var self = this;
         atom.workspace.observeTextEditors(function(editor) {
@@ -62,26 +72,28 @@ module.exports = {
                         editor.onDidSave(function() {
                             if (atom.config.get(packageName + '.compileCSS')) {
                                 if (/^(.sass|.scss)$/.test(file.ext)) {
-                                    if (!atom.config.get(packageName + '.enableSass') || self.nodeSassInstallState != 0) {
+                                    if (!atom.config.get(packageName + '.useGlobalSass') && (!atom.config.get(packageName + '.enableSass') || self.nodeSassInstallState != 0)) {
                                         atom.notifications.addError('Error', {
                                             detail: self.nodeSassInstallState != 0 ? 'node-sass is not installed' : 'disable the function of the node-sass files',
                                             dismissable: false
                                         });
-                                    } else {
-                                        //sass文件 进行关系链查询 编译import文件
-                                        detector.getFilesByImprot(startDir, filePath, function(filePaths, errorMessage) {
-                                            if (filePaths) {
-                                                filePaths.forEach(function(filePath) {
-                                                    self.compileFile(filePath);
-                                                });
-                                            } else {
-                                                atom.notifications.addError('Error', {
-                                                    detail: errorMessage,
-                                                    dismissable: false
-                                                });
-                                            }
-                                        });
+
+                                        return;
                                     }
+
+                                    //sass文件 进行关系链查询 编译import文件
+                                    detector.getFilesByImprot(startDir, filePath, function(filePaths, errorMessage) {
+                                        if (filePaths) {
+                                            filePaths.forEach(function(filePath) {
+                                                self.compileFile(filePath);
+                                            });
+                                        } else {
+                                            atom.notifications.addError('Error', {
+                                                detail: errorMessage,
+                                                dismissable: false
+                                            });
+                                        }
+                                    });
                                 } else {
                                     self.compileFile(filePath);
                                 }
@@ -102,14 +114,36 @@ module.exports = {
     compileFile: function(filePath) {
         var file = path.parse(filePath);
         var outputFile = path.resolve(file.dir, atom.config.get(packageName + '.output'), path.parse(filePath).name + '.js').replace(/\\/g, '/');
-        setTimeout(function() {
-            compile(filePath, outputFile, file.ext, function(message) {
-                atom.notifications.addError('Error', {
-                    detail: message,
-                    dismissable: false
-                });
-            });
-        }, 0);
+
+        if (file.ext == '.css') {
+          // Normal CSS file conversion
+          setTimeout(function() {
+              compile.parseCSS(filePath, outputFile, function(message) {
+                  atom.notifications.addError('Error', {
+                      detail: message,
+                      dismissable: false
+                  });
+              });
+          }, 0);
+        } else if (atom.config.get(packageName + '.useGlobalSass')) {
+          // SASS/SCSS file conversion with global node-sass package
+          compile.parseSCSSGlobally(filePath, outputFile, function(message) {
+              atom.notifications.addError('Error', {
+                  detail: message,
+                  dismissable: false
+              });
+          });
+        } else {
+          // SASS/SCSS file conversion with locally installed node-sass package
+          setTimeout(function() {
+              compile.parseSCSSLocally(filePath, outputFile, function(message) {
+                  atom.notifications.addError('Error', {
+                      detail: message,
+                      dismissable: false
+                  });
+              });
+          }, 0);
+        }
     },
     hasInstallNodeSass: function() {
         //根据系统确认npm安装地址
@@ -192,6 +226,46 @@ module.exports = {
                 this.installNodeSass();
             }
         });
+    },
+    registerMutualExclusionOfNodeSassTypes: function () {
+      [packageName + '.useGlobalSass', packageName + '.enableSass'].forEach((k) => {
+        atom.config.onDidChange(k, (val) => {
+          if (!mutualExclusionInProgress) {
+            mutualExclusionInProgress = true;
+            var isGlobal = k.indexOf('useGlobalSass') > -1;
+
+            this.mutuallyExcludeNodeSassTypes({
+              global: isGlobal ? val.newValue : false,
+              local: !isGlobal ? val.newValue : false
+            });
+          }
+        });
+      });
+    },
+    mutuallyExcludeNodeSassTypes: function (o) {
+      var localSass = packageName + '.enableSass',
+        globalSass = packageName + '.useGlobalSass',
+        unsetOption = function (o) {
+          if (atom.config.get(o)) {
+            atom.config.set(o, false);
+          }
+        };
+
+      // Remove the other option when one of them is selected
+      if (o.global || o.local) {
+        if (o.global) {
+          unsetOption(localSass);
+        } else {
+          unsetOption(globalSass);
+        }
+      } else {
+        // Make sure both are unset
+        unsetOption(localSass);
+        unsetOption(globalSass);
+      }
+      setTimeout(() => {
+        mutualExclusionInProgress = false;
+      }, 10);
     },
     getProvider: function() {
         return require('./provider.js');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "consistent-path": "^2.0.3",
     "css": "^2.2.1",
     "glob": "^7.0.3",
     "minimatch": "^3.0.0",

--- a/test/normalize.css
+++ b/test/normalize.css
@@ -1,0 +1,3 @@
+.randomness {
+  color: "#000000";
+}

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -1,0 +1,12 @@
+import React, {StyleSheet, Dimensions, PixelRatio} from "react-native";
+const {width, height, scale} = Dimensions.get("window"),
+    vw = width / 100,
+    vh = height / 100,
+    vmin = Math.min(vw, vh),
+    vmax = Math.max(vw, vh);
+
+export default StyleSheet.create({
+    "randomness": {
+        "color": "#000000"
+    }
+});


### PR DESCRIPTION
Hello,
I'we added support for using of a global node-sass installation to the package under the useGlobalSass option. From all my testing the original functionality is intact and it should work as intended.

Please take a look over the branch and if it looks ok to you also, merge it into master.
I require this feature due to the errors that the local node-sass is giving us in our environment, and going back to a previous version of node to be able to run this atom package is not an option for me and my company.

Thank you for your time,
Doru Ghepes
